### PR TITLE
Updating python to 3.5 and pandas to 0.19.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.4
+FROM python:3.5
 
 MAINTAINER Julien Maupetit <julien@tailordev.fr>
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RELEASE = 0.18.1
+RELEASE = 0.19.0
 
 all: test
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy==1.11.1
-scipy==0.18.0
+numpy==1.11.2
+scipy==0.18.1
 pandas==0.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 numpy==1.11.1
 scipy==0.18.0
-pandas==0.18.1
+pandas==0.19.0


### PR DESCRIPTION
I did not test this update very thoroughly but tried a few things and it seems to work.

---
- [x] Upgrade Python base image to 3.5
- [x] Upgrade `pandas` to 0.19.0
- [x] Upgrade `scipy` to 0.18.1
- [x] Upgrade `numpy` to 1.12.2
- [x] Bump `Makefile` `RELEASE` to 0.19.0

Last edit by: @jmaupetit
